### PR TITLE
feat: Add method to set screen lock to None

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ The script performs the following actions in order:
     *   Changes the device's screen timeout to **30 minutes** to prevent it from sleeping during the process.
 
 3.  **Removes Screen Lock**:
-    *   Attempts to remove the screen lock (PIN, pattern, password) using several different methods.
-    *   **Note**: This may not work on all devices or Android versions. If it fails, you may need to disable the screen lock manually in `Settings > Security`.
+    *   Attempts to remove the screen lock (PIN, pattern, password) using several different methods, including clearing lock settings and attempting to set a blank password/PIN to force the lock to 'None'.
+    *   **Note**: This may not work on all devices or Android versions due to varying security restrictions. If it fails, you may need to disable the screen lock manually in `Settings > Security`.
 
 4.  **Disables Security Features**:
     *   Adjusts device settings to allow the installation of apps from unknown sources and disables app verification over ADB. This is necessary for installing APKs that are not from the Google Play Store.

--- a/install.bat
+++ b/install.bat
@@ -63,6 +63,11 @@ rem Method 4: Use newer Android API for lock settings
 echo Trying method 4: Using newer lock settings API...
 adb shell cmd lock_settings clear --user 0
 
+rem Method 5: Set a blank password to force lock to 'None'
+echo Trying method 5: Setting blank password/PIN...
+adb shell locksettings set-password ""
+adb shell locksettings set-pin ""
+
 echo NOTE: Screen lock removal may require manual confirmation on the device.
 echo If methods fail, please manually disable screen lock in Settings > Security.
 echo.


### PR DESCRIPTION
This commit adds a new method to the install.bat script to attempt to set the screen lock to 'None' by setting a blank password and PIN. The README.md has also been updated to reflect this change.